### PR TITLE
Add notify service as a wrapper for add message

### DIFF
--- a/custom_components/messages_store/__init__.py
+++ b/custom_components/messages_store/__init__.py
@@ -10,7 +10,8 @@ from .services import (
     get_messages,
     edit_message,
     delete_message,
-    add_bulk_messages
+    add_bulk_messages,
+    notify
 )
 from .services.schemas import (
     ADD_EDIT_SCHEMA,
@@ -89,6 +90,14 @@ async def setup_services(hass: HomeAssistant, entry: config_entries.ConfigEntry)
             'add_bulk_messages',
             wrap_service(add_bulk_messages),
             schema=ADD_BULK_MESSAGES_SCHEMA,
+            supports_response=SupportsResponse.ONLY
+        )
+
+        hass.services.async_register(
+            DOMAIN,
+            'notify',
+            wrap_service(notify),
+            schema=ADD_EDIT_SCHEMA,
             supports_response=SupportsResponse.ONLY
         )
 

--- a/custom_components/messages_store/repository/sqlite_messages_store_repository.py
+++ b/custom_components/messages_store/repository/sqlite_messages_store_repository.py
@@ -13,15 +13,24 @@ class SQLiteMessageStoreRepository(MessagesStore):
                 CREATE TABLE IF NOT EXISTS messages_store (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     slug TEXT NOT NULL,
-                    message TEXT NOT NULL
+                    message TEXT NOT NULL,
+                    priority INTEGER NOT NULL DEFAULT 3,
+                    audience TEXT NOT NULL DEFAULT 'all',
+                    expiration_date TEXT
                 )
+            ''')
+            c.execute('''
+                CREATE INDEX IF NOT EXISTS idx_priority ON messages_store (priority)
+            ''')
+            c.execute('''
+                CREATE INDEX IF NOT EXISTS idx_audience ON messages_store (audience)
             ''')
             conn.commit()
 
-    def insert_message(self, slug: str, message: str):
+    def insert_message(self, slug: str, message: str, priority: int = 3, audience: str = 'all', expiration_date: Optional[str] = None):
         with sqlite3.connect(self.db_path) as conn:
             c = conn.cursor()
-            c.execute("INSERT INTO messages_store (slug, message) VALUES (?, ?)", (slug, message))
+            c.execute("INSERT INTO messages_store (slug, message, priority, audience, expiration_date) VALUES (?, ?, ?, ?, ?)", (slug, message, priority, audience, expiration_date))
             conn.commit()
 
     def slug_exists(self, slug: str) -> bool:

--- a/custom_components/messages_store/services/add_message.py
+++ b/custom_components/messages_store/services/add_message.py
@@ -11,6 +11,9 @@ async def add_message(hass: HomeAssistant, repository: MessagesStore, call: Serv
     try:
         slug = call.data.get('slug')
         message = call.data.get('message')
+        priority = call.data.get('priority', 3)
+        audience = call.data.get('audience', 'all')
+        expiration_date = call.data.get('expiration_date')
 
         if isinstance(message, list):
             message = f"{TAG_SEPARATOR_MESSAGE} ".join(message)
@@ -18,7 +21,7 @@ async def add_message(hass: HomeAssistant, repository: MessagesStore, call: Serv
         if await hass.async_add_executor_job(repository.slug_exists, slug):
             return {"status": False, "message": f"Slug '{slug}' already exists"}
 
-        await hass.async_add_executor_job(repository.insert_message, slug, message)
+        await hass.async_add_executor_job(repository.insert_message, slug, message, priority, audience, expiration_date)
         return {"status": True, "message": f"Message added with slug {slug}"}
 
     except Exception as e:

--- a/custom_components/messages_store/services/notify.py
+++ b/custom_components/messages_store/services/notify.py
@@ -1,0 +1,14 @@
+import logging
+from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse
+from .add_message import add_message
+from .helpers import log_error
+
+_LOGGER = logging.getLogger(__name__)
+
+async def notify(hass: HomeAssistant, repository, call: ServiceCall) -> ServiceResponse:
+    _LOGGER.debug("notify service called")
+    try:
+        response = await add_message(hass, repository, call)
+        return response
+    except Exception as e:
+        return log_error("notify", e)

--- a/custom_components/messages_store/services/schemas.py
+++ b/custom_components/messages_store/services/schemas.py
@@ -12,6 +12,10 @@ MESSAGE_SCHEMA = vol.Any(
     [vol.All(str, vol.Length(min=1, max=2000), validate_no_pipe_char)]  
 )
 
+PRIORITY_SCHEMA = vol.All(vol.Coerce(int), vol.Range(min=1, max=5))
+AUDIENCE_SCHEMA = vol.Any("home", "not home", "all")
+EXPIRATION_DATE_SCHEMA = vol.Any(vol.Date(), vol.Datetime())
+
 FILTER_ITEM_SCHEMA = vol.Schema({
     vol.Required('slug'): SLUG_SCHEMA,
     vol.Optional('replace', default=[]): [vol.Any(str, int, float)],
@@ -21,6 +25,9 @@ FILTER_ITEM_SCHEMA = vol.Schema({
 ADD_EDIT_SCHEMA = vol.Schema({
     vol.Required('slug'): SLUG_SCHEMA,
     vol.Required('message'): MESSAGE_SCHEMA,
+    vol.Optional('priority', default=3): PRIORITY_SCHEMA,
+    vol.Optional('audience', default="all"): AUDIENCE_SCHEMA,
+    vol.Optional('expiration_date'): EXPIRATION_DATE_SCHEMA,
 })
 
 DELETE_SCHEMA = vol.Schema({


### PR DESCRIPTION
Add a new `notify` service as a wrapper for the `add_message` service.

* **Register `notify` service**: Modify `custom_components/messages_store/__init__.py` to register the `notify` service using the `wrap_service` function.
* **Define `notify` service**: Add `custom_components/messages_store/services/notify.py` to define the `notify` service, which calls the `add_message` service and returns its response.
* **Update schema**: Modify `custom_components/messages_store/services/schemas.py` to include `priority`, `audience`, and `expiration_date` fields in the `ADD_EDIT_SCHEMA`.
* **Modify `add_message` function**: Update `custom_components/messages_store/services/add_message.py` to handle `priority`, `audience`, and `expiration_date` fields.
* **Update repository methods**: Modify `custom_components/messages_store/repository/sqlite_messages_store_repository.py` to store `priority`, `audience`, and `expiration_date` fields in the database, adjust the `create_table` method to include columns for these fields, and add indexes for `priority` and `audience`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/spencermamer/messages_store/pull/1?shareId=aebde04f-0981-43e6-87e8-3253cf12fe9b).