### PR TITLE
feat: Add Codespaces devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,70 @@
+{
+  "name": "Home Assistant Custom Component Dev",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11-bullseye",
+  "postCreateCommand": "bash .devcontainer/on-create.sh",
+  "postStartCommand": "bash script/bootstrap",
+  "containerEnv": {
+    "PYTHONASYNCIODEBUG": "1"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "appPort": ["8123:8123"],
+  "runArgs": [
+    "-e",
+    "GIT_EDITOR=code --wait",
+    "--security-opt",
+    "label=disable"
+  ],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "charliermarsh.ruff",
+        "ms-python.pylint",
+        "ms-python.vscode-pylance",
+        "visualstudioexptteam.vscodeintellicode",
+        "redhat.vscode-yaml",
+        "esbenp.prettier-vscode",
+        "GitHub.vscode-pull-request-github",
+        "GitHub.copilot"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/workspaces/${containerWorkspaceFolderBasename}/venv/bin/python",
+        "python.pythonPath": "/workspaces/${containerWorkspaceFolderBasename}/venv/bin/python",
+        "python.terminal.activateEnvInCurrentTerminal": true,
+        "python.testing.pytestArgs": ["--no-cov"],
+        "pylint.importStrategy": "fromEnvironment",
+        "editor.formatOnPaste": false,
+        "editor.formatOnSave": true,
+        "editor.formatOnType": true,
+        "files.trimTrailingWhitespace": true,
+        "terminal.integrated.profiles.linux": {
+          "bash": {
+            "path": "/bin/bash"
+          }
+        },
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "yaml.customTags": [
+          "!input scalar",
+          "!secret scalar",
+          "!include_dir_named scalar",
+          "!include_dir_list scalar",
+          "!include_dir_merge_list scalar",
+          "!include_dir_merge_named scalar"
+        ],
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff"
+        },
+        "json.schemas": [
+          {
+            "fileMatch": ["custom_components/*/manifest.json"],
+            "url": "${containerWorkspaceFolder}/.devcontainer/schemas/manifest_schema.json"
+          }
+        ]
+      }
+    }
+  },
+  "mounts": [
+    "source=${localWorkspaceFolder}/custom_components,target=/config/custom_components,type=bind,consistency=cached"
+  ]
+}

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+echo "on-create.sh script started"
+
+# Ensure script/setup is executable
+chmod +x script/setup
+
+# Run the main setup script
+script/setup
+
+echo "on-create.sh script finished"

--- a/.devcontainer/schemas/manifest_schema.json
+++ b/.devcontainer/schemas/manifest_schema.json
@@ -1,0 +1,391 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Home Assistant integration manifest",
+  "description": "The manifest for a Home Assistant integration",
+  "type": "object",
+  "if": {
+    "properties": { "integration_type": { "const": "virtual" } },
+    "required": ["integration_type"]
+  },
+  "then": {
+    "oneOf": [
+      {
+        "properties": {
+          "domain": {
+            "description": "The domain identifier of the integration.\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#domain",
+            "examples": ["mobile_app"],
+            "type": "string",
+            "pattern": "[0-9a-z_]+"
+          },
+          "name": {
+            "description": "The friendly name of the integration.",
+            "type": "string"
+          },
+          "integration_type": {
+            "description": "The integration type.\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#integration-type",
+            "const": "virtual"
+          },
+          "iot_standards": {
+            "description": "The IoT standards which supports devices or services of this virtual integration.\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#iot-standards",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "enum": ["homekit", "zigbee", "zwave"]
+            }
+          }
+        },
+        "additionalProperties": false,
+        "required": ["domain", "name", "integration_type", "iot_standards"]
+      },
+      {
+        "properties": {
+          "domain": {
+            "description": "The domain identifier of the integration.\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#domain",
+            "examples": ["mobile_app"],
+            "type": "string",
+            "pattern": "[0-9a-z_]+"
+          },
+          "name": {
+            "description": "The friendly name of the integration.",
+            "type": "string"
+          },
+          "integration_type": {
+            "description": "The integration type.\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#integration-type",
+            "const": "virtual"
+          },
+          "supported_by": {
+            "description": "The integration which supports devices or services of this virtual integration.\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#supported-by",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["domain", "name", "integration_type", "supported_by"]
+      }
+    ]
+  },
+  "else": {
+    "properties": {
+      "domain": {
+        "description": "The domain identifier of the integration.\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#domain",
+        "examples": ["mobile_app"],
+        "type": "string",
+        "pattern": "[0-9a-z_]+"
+      },
+      "name": {
+        "description": "The friendly name of the integration.",
+        "type": "string"
+      },
+      "integration_type": {
+        "description": "The integration type.\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#integration-type",
+        "type": "string",
+        "default": "hub",
+        "enum": [
+          "device",
+          "entity",
+          "hardware",
+          "helper",
+          "hub",
+          "service",
+          "system"
+        ]
+      },
+      "config_flow": {
+        "description": "Whether the integration is configurable from the UI.\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#config-flow",
+        "type": "boolean"
+      },
+      "mqtt": {
+        "description": "A list of topics to subscribe for the discovery of devices via MQTT.\nThis requires to specify \"mqtt\" in either the \"dependencies\" or \"after_dependencies\".\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#mqtt",
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "uniqueItems": true
+      },
+      "zeroconf": {
+        "description": "A list containing service domains to search for devices to discover via Zeroconf. Items can either be strings, which discovers all devices in the specific service domain, and/or objects which include filters. (useful for generic service domains like _http._tcp.local.)\nA device is discovered if it matches one of the items, but inside the individual item all properties have to be matched.\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#zeroconf",
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "anyOf": [
+            {
+              "type": "string",
+              "pattern": "^.*\\.local\\.$",
+              "description": "Service domain to search for devices."
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "description": "The service domain to search for devices.",
+                  "examples": ["_http._tcp.local."],
+                  "type": "string",
+                  "pattern": "^.*\\.local\\.$"
+                },
+                "name": {
+                  "description": "The name or name pattern of the devices to filter.",
+                  "type": "string"
+                },
+                "properties": {
+                  "description": "The properties of the Zeroconf advertisement to filter.",
+                  "type": "object",
+                  "additionalProperties": { "type": "string" }
+                }
+              },
+              "required": ["type"],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "uniqueItems": true
+      },
+      "ssdp": {
+        "description": "A list of matchers to find devices discoverable via SSDP/UPnP. In order to be discovered, the device has to match all properties of any of the matchers.\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#ssdp",
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "description": "A matcher for the SSDP discovery.",
+          "type": "object",
+          "properties": {
+            "st": {
+              "type": "string"
+            },
+            "deviceType": {
+              "type": "string"
+            },
+            "manufacturer": {
+              "type": "string"
+            },
+            "modelDescription": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": { "type": "string" }
+        }
+      },
+      "bluetooth": {
+        "description": "A list of matchers to find devices discoverable via Bluetooth. In order to be discovered, the device has to match all properties of any of the matchers.\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#bluetooth",
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "description": "A matcher for the bluetooth discovery",
+          "type": "object",
+          "properties": {
+            "connectable": {
+              "description": "Whether the device needs to be connected to or it works with just advertisement data.",
+              "type": "boolean"
+            },
+            "local_name": {
+              "description": "The name or a name pattern of the device to match.",
+              "type": "string",
+              "pattern": "^([^*]+|[^*]{3,}[*].*)$"
+            },
+            "service_uuid": {
+              "description": "The 128-bit service data UUID to match.",
+              "type": "string",
+              "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+            },
+            "service_data_uuid": {
+              "description": "The 16-bit service data UUID to match, converted into the corresponding 128-bit UUID by replacing the 3rd and 4th byte of `00000000-0000-1000-8000-00805f9b34fb` with the 16-bit UUID.",
+              "examples": ["0000fd3d-0000-1000-8000-00805f9b34fb"],
+              "type": "string",
+              "pattern": "0000[0-9a-f]{4}-0000-1000-8000-00805f9b34fb"
+            },
+            "manufacturer_id": {
+              "description": "The Manufacturer ID to match.",
+              "type": "integer"
+            },
+            "manufacturer_data_start": {
+              "description": "The start bytes of the manufacturer data to match.",
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 255
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "uniqueItems": true
+      },
+      "homekit": {
+        "description": "A list of model names to find devices which are discoverable via HomeKit. A device is discovered if the model name of the device starts with any of the specified model names.\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#homekit",
+        "type": "object",
+        "properties": {
+          "models": {
+            "description": "The model names to search for.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          }
+        },
+        "required": ["models"],
+        "additionalProperties": false
+      },
+      "dhcp": {
+        "description": "A list of matchers to find devices discoverable via DHCP. In order to be discovered, the device has to match all properties of any of the matchers.\nYou can specify an item with \"registered_devices\" set to true to check for devices with MAC addresses specified in the device registry.\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#dhcp",
+        "type": "array",
+        "items": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "registered_devices": {
+                  "description": "Whether the MAC addresses of devices in the device registry should be used for discovery, useful if the discovery is used to update the IP address of already registered devices.",
+                  "const": true
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "hostname": {
+                  "description": "The hostname or hostname pattern to match.",
+                  "type": "string"
+                },
+                "macaddress": {
+                  "description": "The MAC address or MAC address pattern to match.",
+                  "type": "string",
+                  "maxLength": 12
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "uniqueItems": true
+      },
+      "usb": {
+        "description": "A list of matchers to find devices discoverable via USB. In order to be discovered, the device has to match all properties of any of the matchers.\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#usb",
+        "type": "array",
+        "uniqueItems": true,
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "vid": {
+              "description": "The vendor ID to match.",
+              "type": "string",
+              "pattern": "[0-9A-F]{4}"
+            },
+            "pid": {
+              "description": "The product ID to match.",
+              "type": "string",
+              "pattern": "[0-9A-F]{4}"
+            },
+            "description": {
+              "description": "The USB device description to match.",
+              "type": "string"
+            },
+            "manufacturer": {
+              "description": "The manufacturer to match.",
+              "type": "string"
+            },
+            "serial_number": {
+              "description": "The serial number to match.",
+              "type": "string"
+            },
+            "known_devices": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "documentation": {
+        "description": "The website containing the documentation for the integration. It has to be in the format \"https://www.home-assistant.io/integrations/[domain]\"\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#documentation",
+        "type": "string",
+        "pattern": "^https://www.home-assistant.io/integrations/[0-9a-z_]+$",
+        "format": "uri"
+      },
+      "quality_scale": {
+        "description": "The quality scale of the integration.\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#integration-quality-scale",
+        "type": "string",
+        "enum": ["bronze", "silver", "gold", "platinum", "internal", "legacy"]
+      },
+      "requirements": {
+        "description": "The PyPI package requirements for the integration. The package has to be pinned to a specific version.\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#requirements",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "pattern": ".+==.+"
+        },
+        "uniqueItems": true
+      },
+      "dependencies": {
+        "description": "A list of integrations which need to be loaded before this integration can be set up.\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#dependencies",
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "minItems": 1,
+        "uniqueItems": true
+      },
+      "after_dependencies": {
+        "description": "A list of integrations which need to be loaded before this integration is set up when it is configured. The integration will still be set up when the \"after_dependencies\" are not configured.\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#after-dependencies",
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "minItems": 1,
+        "uniqueItems": true
+      },
+      "codeowners": {
+        "description": "A list of GitHub usernames or GitHub team names of the integration owners.\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#code-owners",
+        "type": "array",
+        "minItems": 0,
+        "items": {
+          "type": "string",
+          "pattern": "^@.+$"
+        },
+        "uniqueItems": true
+      },
+      "loggers": {
+        "description": "A list of logger names used by the requirements.\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#loggers",
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "string"
+        },
+        "uniqueItems": true
+      },
+      "disabled": {
+        "description": "The reason for the integration being disabled.",
+        "type": "string"
+      },
+      "iot_class": {
+        "description": "The IoT class of the integration, describing how the integration connects to the device or service.\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#iot-class",
+        "type": "string",
+        "enum": [
+          "assumed_state",
+          "cloud_polling",
+          "cloud_push",
+          "local_polling",
+          "local_push",
+          "calculated"
+        ]
+      },
+      "single_config_entry": {
+        "description": "Whether the integration only supports a single config entry.\nhttps://developers.home-assistant.io/docs/creating_integration_manifest/#single-config-entry-only",
+        "const": true
+      }
+    },
+    "additionalProperties": false,
+    "required": ["domain", "name", "codeowners", "documentation"],
+    "dependencies": {
+      "mqtt": {
+        "anyOf": [
+          { "required": ["dependencies"] },
+          { "required": ["after_dependencies"] }
+        ]
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,37 @@
-__pycache__
+# Python virtual environment
+venv/
+.venv/
+
+# Home Assistant configuration directory
+config/
+
+# VSCode user settings
+.vscode/settings.json
+!.vscode/settings.default.json
+# (allow settings.default.json, but ignore user's specific settings.json)
+
+# Python caches
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Build artifacts
+build/
+dist/
+*.egg-info/
+wheels/
+
+# Coverage reports
+.coverage
+coverage.xml
+htmlcov/
+
+# Test reports
+.pytest_cache/
+junit/
+
+# IDE specific files
+.idea/
+*.swp
+*.swo

--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -1,0 +1,52 @@
+{
+  "python.defaultInterpreterPath": "/workspaces/${workspaceFolderBasename}/venv/bin/python",
+  "python.pythonPath": "/workspaces/${workspaceFolderBasename}/venv/bin/python",
+  "python.terminal.activateEnvInCurrentTerminal": true,
+  "python.testing.pytestEnabled": true,
+  "python.testing.pytestArgs": [
+    "tests",
+    "--no-cov"
+  ],
+  "pylint.importStrategy": "fromEnvironment",
+  "pylint.args": [
+    "--disable=C0114,C0115,C0116"
+  ],
+  "editor.formatOnSave": true,
+  "editor.formatOnPaste": false,
+  "editor.formatOnType": true,
+  "files.trimTrailingWhitespace": true,
+  "yaml.customTags": [
+    "!input scalar",
+    "!secret scalar",
+    "!include_dir_named scalar",
+    "!include_dir_list scalar",
+    "!include_dir_merge_list scalar",
+    "!include_dir_merge_named scalar"
+  ],
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.codeActionsOnSave": {
+      "source.fixAll": "explicit",
+      "source.organizeImports": "explicit"
+    }
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "files.trimTrailingWhitespace": false
+  },
+  "json.schemas": [
+    {
+      "fileMatch": [
+        "custom_components/*/manifest.json",
+        "*/custom_components/*/manifest.json"
+      ],
+      "url": "${workspaceFolder}/.devcontainer/schemas/manifest_schema.json"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -312,3 +312,59 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 ## Contributing
 
 Feel free to contribute to this project by submitting issues or pull requests. Please ensure that your contributions follow the established coding guidelines and are thoroughly tested.
+
+## Development Environment Setup
+
+This repository includes a pre-configured development container (devcontainer) for use with GitHub Codespaces or VS Code Remote - Containers. This provides a consistent and fully set up environment for developing and testing this custom component.
+
+### Using GitHub Codespaces
+
+1.  Navigate to the main page of this repository on GitHub.
+2.  Click the green "Code" button.
+3.  Select the "Codespaces" tab.
+4.  Click "Create codespace on main" (or your current branch). GitHub will then set up the Codespace, which may take a few minutes.
+5.  Once ready, VS Code will open in your browser, or you can open it in your local VS Code application. The environment will be automatically configured based on the `.devcontainer/devcontainer.json` file.
+
+### Using VS Code Remote - Containers (Local)
+
+1.  **Prerequisites**:
+    *   [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed and running.
+    *   [Visual Studio Code](https://code.visualstudio.com/) installed.
+    *   The [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) installed in VS Code.
+2.  **Clone the repository**:
+    ```bash
+    git clone https://github.com/your-username/your-repository-name.git # Replace with actual repo URL
+    cd your-repository-name # Replace with actual repo directory
+    ```
+3.  **Open in Container**:
+    *   Open VS Code.
+    *   Open the Command Palette (Ctrl+Shift+P or Cmd+Shift+P).
+    *   Type and select: `Dev Containers: Reopen in Container`.
+    *   VS Code will build the dev container image (if not already built) and start the container. This might take several minutes on the first run.
+
+### What's Included?
+
+The development container comes with:
+
+*   Python 3.11+
+*   Home Assistant Core (installed via `requirements_dev.txt`)
+*   `uv` for fast package management
+*   Pre-configured VS Code extensions for Python development (Ruff, Pylint, Pylance), YAML, Prettier, and GitHub Copilot.
+*   Linters and formatters set up (Ruff, Prettier).
+*   A Home Assistant `config` directory ready for use.
+*   The custom component from this repository mounted into the `/config/custom_components` directory of the Home Assistant instance within the container.
+
+### Running Home Assistant
+
+*   Once the devcontainer is up and running, Home Assistant should start automatically as part of the `postStartCommand`.
+*   If you need to start it manually or if it was stopped, open a terminal in VS Code (Terminal > New Terminal) and run:
+    ```bash
+    hass -c config
+    ```
+*   You can access the Home Assistant web interface at [http://localhost:8123](http://localhost:8123) in your browser.
+
+### Development Workflow
+
+1.  Make your code changes in the `custom_components/messages_store/` directory.
+2.  The changes will be reflected live in the running Home Assistant instance due to the bind mount. You may need to restart Home Assistant (via the Developer Tools > Server Management in HA UI, or by restarting the `hass` command) for some changes to take effect.
+3.  Use the integrated terminal for Git commands, running tests, etc.

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,14 @@
+# Core development dependencies
+homeassistant~=2024.1  # Or specify a more recent version if needed
+uv>=0.1.0
+
+# Linters, formatters, and testing tools
+ruff==0.4.4 # Or a newer compatible version
+pylint
+prettier
+pytest
+pytest-cov
+
+# For HASS development
+voluptuous-serialize
+# Add any other specific development dependencies for your custom component below

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Resolve all dependencies that the application requires to run.
+
+# Stop on errors
+set -e
+
+# Get the directory of the script
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+# Navigate to the root of the repository
+cd "$SCRIPT_DIR/.."
+
+echo "Starting script/bootstrap..."
+echo "Current working directory: $(pwd)"
+
+# Ensure virtual environment is active
+if [ -z "$VIRTUAL_ENV" ]; then
+  if [ -d "venv" ]; then
+    echo "Activating virtual environment..."
+    source venv/bin/activate
+  else
+    echo "Error: Virtual environment not found. Please run script/setup first."
+    exit 1
+  fi
+fi
+
+echo "Installing/updating core development dependencies (wheel, colorlog, awesomeversion)..."
+uv pip install wheel colorlog awesomeversion --upgrade
+
+# Check for requirements_dev.txt and install if it exists
+REQUIREMENTS_DEV_FILE="requirements_dev.txt"
+if [ -f "$REQUIREMENTS_DEV_FILE" ]; then
+  echo "Installing dependencies from $REQUIREMENTS_DEV_FILE..."
+  uv pip install -r "$REQUIREMENTS_DEV_FILE"
+else
+  echo "Warning: $REQUIREMENTS_DEV_FILE not found. Skipping."
+fi
+
+# Check for requirements_test.txt and install if it exists (often part of dev requirements)
+REQUIREMENTS_TEST_FILE="requirements_test.txt"
+if [ -f "$REQUIREMENTS_TEST_FILE" ]; then
+  echo "Installing dependencies from $REQUIREMENTS_TEST_FILE..."
+  uv pip install -r "$REQUIREMENTS_TEST_FILE"
+else
+  echo "Warning: $REQUIREMENTS_TEST_FILE not found. Skipping."
+fi
+
+echo "script/bootstrap finished."

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Setups the repository.
+
+# Stop on errors
+set -e
+
+echo "Starting script/setup..."
+
+# Get the directory of the script
+SCRIPT_DIR="$( cd "$( dirname "\${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+# Navigate to the root of the repository, assuming this script is in a 'script' subdirectory
+cd "\$SCRIPT_DIR/.."
+
+echo "Current working directory: \$(pwd)"
+
+# Add default vscode settings if not existing
+SETTINGS_FILE=./.vscode/settings.json
+SETTINGS_DEFAULT_FILE=./.vscode/settings.default.json # Changed from SETTINGS_TEMPLATE_FILE
+if [ -f "\$SETTINGS_DEFAULT_FILE" ]; then
+    if [ ! -f "\$SETTINGS_FILE" ]; then
+        echo "Copying \$SETTINGS_DEFAULT_FILE to \$SETTINGS_FILE."
+        mkdir -p ./.vscode
+        cp "\$SETTINGS_DEFAULT_FILE" "\$SETTINGS_FILE"
+    else
+        echo "\$SETTINGS_FILE already exists. Skipping copy."
+    fi
+else
+    echo "Warning: \$SETTINGS_DEFAULT_FILE not found. Skipping VS Code settings setup."
+fi
+
+echo "Creating config directory if it doesn't exist..."
+mkdir -p config
+
+echo "Setting up Python virtual environment..."
+if [ ! -n "\$VIRTUAL_ENV" ]; then
+  if [ -x "\$(command -v uv)" ]; then
+    uv venv venv
+  else
+    python3 -m venv venv
+  fi
+  echo "Activating virtual environment..."
+  source venv/bin/activate
+else
+  echo "Already in a virtual environment."
+fi
+
+echo "Ensuring uv is installed..."
+if ! [ -x "\$(command -v uv)" ]; then
+  python3 -m pip install uv
+fi
+
+echo "Running bootstrap script..."
+# Ensure bootstrap is executable and run it
+chmod +x script/bootstrap
+script/bootstrap
+
+# Install pre-commit hooks if a configuration exists
+if [ -f ".pre-commit-config.yaml" ]; then
+  echo "Installing pre-commit hooks..."
+  uv pip install pre-commit
+  pre-commit install
+else
+  echo "No .pre-commit-config.yaml found. Skipping pre-commit setup."
+fi
+
+echo "Installing the custom component in editable mode..."
+# This assumes your custom component is under custom_components/messages_store
+# and that it has a pyproject.toml or setup.py for installation.
+# If your component doesn't have a pyproject.toml for build, this might need adjustment.
+# For now, we ensure homeassistant is installed, which is the primary dependency.
+uv pip install -e ./custom_components/messages_store --config-settings editable_mode=compat
+
+echo "Ensuring Home Assistant configuration..."
+hass --script ensure_config -c config
+
+# Add default logger settings if not present in configuration.yaml
+CONFIG_YAML="config/configuration.yaml"
+if [ -f "\$CONFIG_YAML" ]; then
+    if ! grep -q "logger:" "\$CONFIG_YAML"; then
+        echo "Adding default logger configuration to \$CONFIG_YAML..."
+        echo "
+logger:
+  default: info
+  logs:
+    homeassistant.components.automation: debug
+    homeassistant.components.script: debug
+    custom_components.messages_store: debug # Add your custom component here
+" >> "\$CONFIG_YAML"
+    else
+        echo "Logger configuration already present in \$CONFIG_YAML."
+    fi
+else
+    echo "Warning: \$CONFIG_YAML not found. Skipping logger configuration."
+fi
+
+echo "script/setup finished."


### PR DESCRIPTION
This sets up a complete development environment for Home Assistant custom component development using VS Code devcontainers (Codespaces).

This includes:
- A `.devcontainer/devcontainer.json` configured with a Python 3.11 image, necessary VS Code extensions, port forwarding, and environment settings.
- Helper scripts `script/setup` and `script/bootstrap` to initialize the virtual environment, install dependencies (using uv), and prepare the Home Assistant configuration.
- `requirements_dev.txt` listing core development dependencies like Home Assistant, linters (Ruff, Pylint), formatters (Prettier), and testing tools.
- Default VS Code workspace settings in `.vscode/settings.default.json` for interpreter paths, formatters, and testing.
- An updated `.gitignore` to exclude common development artifacts.
- Documentation in `README.md` explaining how to use the devcontainer with GitHub Codespaces or locally with VS Code Remote - Containers.

This setup aims to provide a consistent and ready-to-use environment for you, simplifying the onboarding process and ensuring all necessary tools are available.