### PR TITLE
Remove unused path translations

### DIFF
--- a/custom_components/messages_store/translations/en.json
+++ b/custom_components/messages_store/translations/en.json
@@ -2,15 +2,8 @@
     "config": {
         "step": {
             "user": {
-                "title": "Notices Store",
-                "description": "Path to the SQLite database for storing notices. Uses Home Assistant's database if left default.",
-                "data": {
-                    "path": "SQLite database"
-                }
+                "title": "Notices Store"
             }
-        },
-        "error": {
-            "invalid_path": "Please provide a valid path to the SQLite database file."
         },
         "abort": {
             "single_instance_allowed": "Only one instance of this process is allowed to run at a time."
@@ -19,15 +12,8 @@
     "options": {
         "step": {
             "init": {
-                "title": "Notices Store",
-                "description": "Path to the SQLite database for storing notices. Uses Home Assistant's database if left default.",
-                "data": {
-                    "path": "SQLite database"
-                }
+                "title": "Notices Store"
             }
-        },
-        "error": {
-            "invalid_path": "Please provide a valid path to the SQLite database file."
         }
     }
 }


### PR DESCRIPTION
## Summary
- clean up leftover keys for a custom DB path

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68493386c8d483238fbe02f27a69bbd8