### PR TITLE
Update Home Assistant devcontainer setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,6 @@
 {
-  "name": "Home Assistant Custom Component Dev",
-  "image": "mcr.microsoft.com/devcontainers/python:3.11-bullseye",
-  "postCreateCommand": "bash .devcontainer/on-create.sh",
+  "name": "Home Assistant Dev",
+  "postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder} && bash .devcontainer/on-create.sh",
   "postStartCommand": "bash script/bootstrap",
   "containerEnv": {
     "PYTHONASYNCIODEBUG": "1"
@@ -9,7 +8,10 @@
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
-  "appPort": ["8123:8123"],
+  "appPort": [
+    "8123:8123",
+    "5683:5683/udp"
+  ],
   "runArgs": [
     "-e",
     "GIT_EDITOR=code --wait",
@@ -29,21 +31,23 @@
         "GitHub.copilot"
       ],
       "settings": {
-        "python.defaultInterpreterPath": "/workspaces/${containerWorkspaceFolderBasename}/venv/bin/python",
-        "python.pythonPath": "/workspaces/${containerWorkspaceFolderBasename}/venv/bin/python",
+        "python.defaultInterpreterPath": "/home/vscode/.local/ha-venv/bin/python",
+        "python.pythonPath": "/home/vscode/.local/ha-venv/bin/python",
         "python.terminal.activateEnvInCurrentTerminal": true,
-        "python.testing.pytestArgs": ["--no-cov"],
+        "python.testing.pytestArgs": [
+          "--no-cov"
+        ],
         "pylint.importStrategy": "fromEnvironment",
         "editor.formatOnPaste": false,
         "editor.formatOnSave": true,
         "editor.formatOnType": true,
         "files.trimTrailingWhitespace": true,
         "terminal.integrated.profiles.linux": {
-          "bash": {
-            "path": "/bin/bash"
+          "zsh": {
+            "path": "/usr/bin/zsh"
           }
         },
-        "terminal.integrated.defaultProfile.linux": "bash",
+        "terminal.integrated.defaultProfile.linux": "zsh",
         "yaml.customTags": [
           "!input scalar",
           "!secret scalar",
@@ -57,7 +61,9 @@
         },
         "json.schemas": [
           {
-            "fileMatch": ["custom_components/*/manifest.json"],
+            "fileMatch": [
+              "custom_components/*/manifest.json"
+            ],
             "url": "${containerWorkspaceFolder}/.devcontainer/schemas/manifest_schema.json"
           }
         ]
@@ -66,5 +72,7 @@
   },
   "mounts": [
     "source=${localWorkspaceFolder}/custom_components,target=/config/custom_components,type=bind,consistency=cached"
-  ]
+  ],
+  "context": "..",
+  "dockerFile": "../Dockerfile.dev"
 }

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,67 @@
+FROM mcr.microsoft.com/devcontainers/python:1-3.13
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Uninstall pre-installed formatting and linting tools
+# They would conflict with our pinned versions
+RUN \
+    pipx uninstall pydocstyle \
+    && pipx uninstall pycodestyle \
+    && pipx uninstall mypy \
+    && pipx uninstall pylint
+
+RUN \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        bluez \
+        ffmpeg \
+        libudev-dev \
+        libavformat-dev \
+        libavcodec-dev \
+        libavdevice-dev \
+        libavutil-dev \
+        libgammu-dev \
+        libswscale-dev \
+        libswresample-dev \
+        libavfilter-dev \
+        libpcap-dev \
+        libturbojpeg0 \
+        libyaml-dev \
+        libxml2 \
+        git \
+        cmake \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add go2rtc binary
+COPY --from=ghcr.io/alexxit/go2rtc:latest /usr/local/bin/go2rtc /bin/go2rtc
+
+# Install uv
+RUN pip3 install uv
+
+WORKDIR /usr/src
+
+# Setup hass-release
+RUN git clone --depth 1 https://github.com/home-assistant/hass-release \
+    && uv pip install --system -e hass-release/ \
+    && chown -R vscode /usr/src/hass-release/data
+
+USER vscode
+ENV VIRTUAL_ENV="/home/vscode/.local/ha-venv"
+RUN uv venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+WORKDIR /tmp
+
+# Install Python dependencies from requirements if present
+COPY requirements.txt ./
+COPY homeassistant/package_constraints.txt homeassistant/package_constraints.txt
+RUN uv pip install -r requirements.txt
+COPY requirements_test.txt requirements_test_pre_commit.txt ./
+RUN uv pip install -r requirements_test.txt
+
+WORKDIR /workspaces
+
+# Set the default shell to bash instead of sh
+ENV SHELL /bin/bash

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ This repository includes a pre-configured development container (devcontainer) f
 
 The development container comes with:
 
-*   Python 3.11+
+*   Python 3.13+
 *   Home Assistant Core (installed via `requirements_dev.txt`)
 *   `uv` for fast package management
 *   Pre-configured VS Code extensions for Python development (Ruff, Pylint, Pylance), YAML, Prettier, and GitHub Copilot.

--- a/script/setup
+++ b/script/setup
@@ -1,39 +1,34 @@
 #!/usr/bin/env bash
-# Setups the repository.
-
-# Stop on errors
+# Set up the repository.
 set -e
 
 echo "Starting script/setup..."
 
-# Get the directory of the script
-SCRIPT_DIR="$( cd "$( dirname "\${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-# Navigate to the root of the repository, assuming this script is in a 'script' subdirectory
-cd "\$SCRIPT_DIR/.."
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$SCRIPT_DIR/.."
 
-echo "Current working directory: \$(pwd)"
+echo "Current working directory: $(pwd)"
 
-# Add default vscode settings if not existing
 SETTINGS_FILE=./.vscode/settings.json
-SETTINGS_DEFAULT_FILE=./.vscode/settings.default.json # Changed from SETTINGS_TEMPLATE_FILE
-if [ -f "\$SETTINGS_DEFAULT_FILE" ]; then
-    if [ ! -f "\$SETTINGS_FILE" ]; then
-        echo "Copying \$SETTINGS_DEFAULT_FILE to \$SETTINGS_FILE."
-        mkdir -p ./.vscode
-        cp "\$SETTINGS_DEFAULT_FILE" "\$SETTINGS_FILE"
-    else
-        echo "\$SETTINGS_FILE already exists. Skipping copy."
-    fi
+SETTINGS_DEFAULT_FILE=./.vscode/settings.default.json
+if [ -f "$SETTINGS_DEFAULT_FILE" ]; then
+  if [ ! -f "$SETTINGS_FILE" ]; then
+    echo "Copying $SETTINGS_DEFAULT_FILE to $SETTINGS_FILE."
+    mkdir -p ./.vscode
+    cp "$SETTINGS_DEFAULT_FILE" "$SETTINGS_FILE"
+  else
+    echo "$SETTINGS_FILE already exists. Skipping copy."
+  fi
 else
-    echo "Warning: \$SETTINGS_DEFAULT_FILE not found. Skipping VS Code settings setup."
+  echo "Warning: $SETTINGS_DEFAULT_FILE not found. Skipping VS Code settings setup."
 fi
 
 echo "Creating config directory if it doesn't exist..."
 mkdir -p config
 
 echo "Setting up Python virtual environment..."
-if [ ! -n "\$VIRTUAL_ENV" ]; then
-  if [ -x "\$(command -v uv)" ]; then
+if [ -z "$VIRTUAL_ENV" ]; then
+  if command -v uv >/dev/null 2>&1; then
     uv venv venv
   else
     python3 -m venv venv
@@ -45,16 +40,14 @@ else
 fi
 
 echo "Ensuring uv is installed..."
-if ! [ -x "\$(command -v uv)" ]; then
+if ! command -v uv >/dev/null 2>&1; then
   python3 -m pip install uv
 fi
 
 echo "Running bootstrap script..."
-# Ensure bootstrap is executable and run it
 chmod +x script/bootstrap
 script/bootstrap
 
-# Install pre-commit hooks if a configuration exists
 if [ -f ".pre-commit-config.yaml" ]; then
   echo "Installing pre-commit hooks..."
   uv pip install pre-commit
@@ -63,34 +56,28 @@ else
   echo "No .pre-commit-config.yaml found. Skipping pre-commit setup."
 fi
 
-echo "Installing the custom component in editable mode..."
-# This assumes your custom component is under custom_components/messages_store
-# and that it has a pyproject.toml or setup.py for installation.
-# If your component doesn't have a pyproject.toml for build, this might need adjustment.
-# For now, we ensure homeassistant is installed, which is the primary dependency.
-uv pip install -e ./custom_components/messages_store --config-settings editable_mode=compat
+# Skipping editable install since no pyproject or setup.py is present
 
 echo "Ensuring Home Assistant configuration..."
 hass --script ensure_config -c config
 
-# Add default logger settings if not present in configuration.yaml
 CONFIG_YAML="config/configuration.yaml"
-if [ -f "\$CONFIG_YAML" ]; then
-    if ! grep -q "logger:" "\$CONFIG_YAML"; then
-        echo "Adding default logger configuration to \$CONFIG_YAML..."
-        echo "
+if [ -f "$CONFIG_YAML" ]; then
+  if ! grep -q "logger:" "$CONFIG_YAML"; then
+    echo "Adding default logger configuration to $CONFIG_YAML..."
+    cat >> "$CONFIG_YAML" <<'CONF'
 logger:
   default: info
   logs:
     homeassistant.components.automation: debug
     homeassistant.components.script: debug
     custom_components.messages_store: debug # Add your custom component here
-" >> "\$CONFIG_YAML"
-    else
-        echo "Logger configuration already present in \$CONFIG_YAML."
-    fi
+CONF
+  else
+    echo "Logger configuration already present in $CONFIG_YAML."
+  fi
 else
-    echo "Warning: \$CONFIG_YAML not found. Skipping logger configuration."
+  echo "Warning: $CONFIG_YAML not found. Skipping logger configuration."
 fi
 
 echo "script/setup finished."


### PR DESCRIPTION
## Summary
- update devcontainer to match latest Home Assistant dev docs
- add Dockerfile.dev for building dev container
- fix setup script quoting issues
- update README to mention Python 3.13

## Testing
- `bash script/setup`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684a13f4949083238733c7868ed15dfa